### PR TITLE
Remove hashtag from URL

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -39,6 +39,7 @@ const routes = [
 
 const router = new VueRouter({
     routes,
+    mode: 'history',
     scrollBehavior() {
         document.getElementById('app').scrollIntoView();
     }


### PR DESCRIPTION
This fix removes the hashtag from the URL.

from: https://www.myrecipes.at/#/
to: https://www.myrecipes.at